### PR TITLE
Change baseimage

### DIFF
--- a/.github/workflows/buld-docker-image.yml
+++ b/.github/workflows/buld-docker-image.yml
@@ -18,4 +18,7 @@ jobs:
       - name: compose-run
         shell: bash
         run: |
+          cp -r modules/join_logo_scp_trial/JL .
+          cp -r modules/join_logo_scp_trial/setting .
+          cp -r modules/join_logo_scp_trial/src .
           docker-compose up --build

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ DockerとDocker-composeを用いて動作させます。
 ### 確認環境
 同梱しているDocker環境にて動作を確認しました。  
 
-## セットアップ方法
+## 動作確認用環境セットアップ方法
 このセットアップにはDockerとDocker-composeが必要です。  
 ローカルにインストールしたい場合はDockerファイルを読んで手順をなぞってください。  
+あくまで、動作確認用ですので使い込みたい方は自前でDockerfileを作成することや、他のDockerfileに組み込むことを検討してください。
 初回は次の通りに実行します。
 ````
 git clone --recursive https://github.com/tobitti0/JoinLogoScpTrialSetLinux.git
@@ -25,23 +26,31 @@ cp -r modules/join_logo_scp_trial/setting .
 cp -r modules/join_logo_scp_trial/src .
 docker-compose up --build
 ````
-FFmpegその他ライブラリをビルドしますのではやくても10分程度はかかります。  
-環境次第ではもっとかかると思います。  
-気長に待ってください。
+[docker-avisynthplus](https://github.com/users/tobitti0/packages/container/package/docker-avisynthplus)をベースイメージとして使用します。
+ある程度のFFmpegが使用できると思います。
+
 次のログが出たら完了です。  
 ````bash
+Successfully tagged join_logo_scp_trial:latest
+Recreating join_logo_scp_trial ... done
 Attaching to join_logo_scp_trial
-join_logo_scp_trial    | 
+join_logo_scp_trial    |
 join_logo_scp_trial    | > join_logo_scp_trial@1.0.0 start /join_logo_scp_trial
 join_logo_scp_trial    | > node src/jlse.js "-i" "--help"
 join_logo_scp_trial    |
-join_logo_scp_trial    | invalid file extension .
 join_logo_scp_trial    | Options:
-join_logo_scp_trial    |   --version     Show version number                                    [boolean]
-join_logo_scp_trial    |   --input, -i   path to ts file                              [string] [required]
-join_logo_scp_trial    |   --filter, -f  enable to ffmpeg filter output        [boolean] [default: false]
-join_logo_scp_trial    |   --help        Show help                                              [boolean]
-Join_logo_scp_trial exited with code 0
+join_logo_scp_trial    |   --version      Show version number                                   [boolean]
+join_logo_scp_trial    |   --input, -i    path to ts file                             [string] [required]
+join_logo_scp_trial    |   --filter, -f   enable to ffmpeg filter output       [boolean] [default: false]
+join_logo_scp_trial    |   --encode, -e   enable to ffmpeg encode              [boolean] [default: false]
+join_logo_scp_trial    |   --target, -t   select encord target
+join_logo_scp_trial    |                         [choices: "cutcm", "cutcm_logo"] [default: "cutcm_logo"]
+join_logo_scp_trial    |   --option, -o   set ffmpeg option                        [string] [default: ""]
+join_logo_scp_trial    |   --outdir, -d   set encorded file dir                    [string] [default: ""]
+join_logo_scp_trial    |   --outname, -n  set encorded file name                   [string] [default: ""]
+join_logo_scp_trial    |   --remove, -r   remove avs files                     [boolean] [default: false]
+join_logo_scp_trial    |   --help         Show help                                             [boolean]
+join_logo_scp_trial exited with code 0
 ````
 logoフォルダが生成されていると思うので、そこにロゴデータを入れておきます。
 ## 使用方法

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     image: join_logo_scp_trial
     build:
       context: .
-      dockerfile: ./docker/ubuntu19.10/Dockerfile
+      dockerfile: ./docker/Dockerfile
+#      dockerfile: ./docker/ubuntu19.10/Dockerfile
 #      dockerfile: ./docker/cuda:10.0-devel-ubuntu18.04/Dockerfile
 #    runtime: nvidia
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,52 @@
+FROM ghcr.io/tobitti0/docker-avisynthplus:latest as build
+
+ADD modules /tmp/modules
+
+RUN set -xe && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+      curl git make gcc g++ cmake libboost-all-dev
+
+# join_logo_scp_trial
+RUN cd /tmp/modules/chapter_exe/src && \
+    make && \
+    mv chapter_exe /tmp/modules/join_logo_scp_trial/bin/ && \
+    cd /tmp/modules/logoframe/src && \
+    make && \
+    mv logoframe /tmp/modules/join_logo_scp_trial/bin/ && \
+    cd /tmp/modules/join_logo_scp/src && \
+    make && \
+    mv join_logo_scp /tmp/modules/join_logo_scp_trial/bin/ && \
+    cd /tmp/modules/tsdivider/ && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make && \
+    mv tsdivider /tmp/modules/join_logo_scp_trial/bin/ && \
+    mv /tmp/modules/join_logo_scp_trial /join_logo_scp_trial && \
+    cd /join_logo_scp_trial
+
+RUN set -xe && \
+    git clone https://github.com/tobitti0/delogo-AviSynthPlus-Linux && \
+    cd delogo-AviSynthPlus-Linux/src && \
+    make && \
+    cp libdelogo.so /join_logo_scp_trial
+
+RUN set -xe && \
+    curl -O -sL https://deb.nodesource.com/setup_10.x && \
+    cp setup_10.x /join_logo_scp_trial
+
+FROM ghcr.io/tobitti0/docker-avisynthplus:latest as release
+MAINTAINER  Tobitti <mail@tobitti.net>
+WORKDIR /join_logo_scp_trial
+COPY --from=build /join_logo_scp_trial /join_logo_scp_trial
+RUN bash setup_10.x && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y nodejs libboost-filesystem-dev libboost-program-options-dev libboost-system-dev && \
+    node -v && \
+    npm --version &&\
+    mv libdelogo.so /usr/local/lib/avisynth && \
+    ls /usr/local/lib/avisynth && \
+    npm install
+ENTRYPOINT ["npm", "start", "--" ,"-i"]
+CMD ["--help"]


### PR DESCRIPTION
Dockerfileで使用しているBaseimageを自前の[docker-avisynthplus](https://github.com/users/tobitti0/packages/container/package/docker-avisynthplus)に切り替えた。

あくまで手軽に試してもらうためのDockerfileなのでここで詰まることがないようにしたい。
すでにビルドし、GitHub Container Registryに上げた前提環境（Avisynth+,FFmpeg,l-smash-source)を用いることで確実に環境を構築できるようになる。
加えてすでにFFmpeg等をビルドしてあるので今までに比べ格段に早く環境を構築できる。

更に今まで含めていなかった、[delogo-AviSynthPlus-Linux](https://github.com/tobitti0/delogo-AviSynthPlus-Linux)も含むようにした。